### PR TITLE
Update icon.cson

### DIFF
--- a/snippets/icon.cson
+++ b/snippets/icon.cson
@@ -3,7 +3,7 @@
   'Glyphicon':
     'prefix': 'gly'
     'body': """
-    <span class="glyphicon glyphicon-$1"></span>
+    <span class="glyphicons glyphicons-$1"></span>
     """
 
   'Glyphicon Halflings':


### PR DESCRIPTION
The class-name for Glyphicon Pro is `glyphicons`, only the free subset included in Bootstrap 3 uses `glyphicon` (note the missing "s")