### PR TITLE
Remove deprecated class

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ The plugin has Glyphicon and Fontawesome support.
   * `conf`: Generates fluid container: `<div class="container-fluid"></div>`
   * `row`: Generates column container: `<div class="row"></div>`
   * `col-`: Generates column: `<div class="col-..."></div>`
-  * `col-xs`: Generates extra small column: `<div class="col-xs-..."></div>`
   * `col-sm`: Generates small column: `<div class="col-sm-..."></div>`
   * `col-md`: Generates medium column: `<div class="col-md-..."></div>`
   * `col-lg`: Generates large column: `<div class="col-lg-..."></div>`

--- a/snippets/layout.grid.cson
+++ b/snippets/layout.grid.cson
@@ -27,16 +27,8 @@
   'Column':
     'prefix': 'col-'
     'body': """
-    <div class="col-${1:xs|sm|md|lg|xl}-${2:1-12}">
+    <div class="col-${1:sm|md|lg|xl}-${2:1-12}">
       $3
-    </div>
-    """
-
-  'Column Extra Small':
-    'prefix': 'col-xs'
-    'body': """
-    <div class="col-xs-${1:1-12}">
-      $0
     </div>
     """
 


### PR DESCRIPTION
Removed `col-xs` snippet because it is no longer supported in Bootstrap 4.0.0 beta2.